### PR TITLE
Changing to match example playbook.

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,7 +14,7 @@
     - config
 
 - name: Ensure corosync services
-  corosync_service: name={{item.name}} ver={{item.ver}} user={{item.user}} group={{item.group}}
+  corosync_service: name={{item.service}} ver={{item.ver}} user={{item.user}} group={{item.group}}
   with_items: services
   when: services is defined
   notify:


### PR DESCRIPTION
Example playbook lists variable as service.  Will thrown an unknown object error if run using example with this code.